### PR TITLE
Implement auth-based home screen

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,10 @@
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+
+class DefaultFirebaseOptions {
+  static const FirebaseOptions currentPlatform = FirebaseOptions(
+    apiKey: 'YOUR_API_KEY',
+    appId: 'YOUR_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+  );
+}

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'screens/login_screen.dart';
+import 'screens/doctor_dashboard.dart';
+import 'screens/patient_dashboard.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<User?>(
+      stream: FirebaseAuth.instance.authStateChanges(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        if (!snapshot.hasData) {
+          return const LoginScreen();
+        }
+        final uid = snapshot.data!.uid;
+        return FutureBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+          future: FirebaseFirestore.instance.collection('doctors').doc(uid).get(),
+          builder: (context, docSnapshot) {
+            if (docSnapshot.connectionState == ConnectionState.waiting) {
+              return const Scaffold(
+                body: Center(child: CircularProgressIndicator()),
+              );
+            }
+            if (docSnapshot.data?.exists ?? false) {
+              return const DoctorDashboard();
+            }
+            return const PatientDashboard();
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'home_screen.dart';
+import 'firebase_options.dart';
 
-void main() {
-  runApp( MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+  runApp(const MyApp());
 }
 
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Medical App',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomeScreen(),
+    );
+  }
+}
 

--- a/lib/screens/doctor_dashboard.dart
+++ b/lib/screens/doctor_dashboard.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class DoctorDashboard extends StatelessWidget {
+  const DoctorDashboard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Doctor Dashboard')),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('appointments')
+            .where('doctorId', isEqualTo: user?.uid)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final appts = snapshot.data!.docs;
+          if (appts.isEmpty) {
+            return const Center(child: Text('No appointments'));
+          }
+          return ListView(
+            children: appts.map((doc) {
+              final data = doc.data() as Map<String, dynamic>;
+              final date = (data['date'] as Timestamp).toDate();
+              return ListTile(
+                title: Text(date.toString()),
+                subtitle: Text(data['service'] ?? ''),
+              );
+            }).toList(),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'patient_dashboard.dart';
+import 'doctor_dashboard.dart';
+import 'sign_up_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _controller;
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Login'),
+        bottom: TabBar(
+          controller: _controller,
+          tabs: const [
+            Tab(text: 'Doctor Account'),
+            Tab(text: 'Patient Account'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _controller,
+        children: [
+          _buildForm(),
+          _buildForm(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextField(
+            controller: _emailController,
+            decoration: const InputDecoration(labelText: 'Email Address'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _passwordController,
+            obscureText: true,
+            decoration: const InputDecoration(labelText: 'Password'),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.blue,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+            onPressed: _login,
+            child: const Text('Log In'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => SignUpScreen(isDoctor: _controller.index == 0),
+                ),
+              );
+            },
+            child: const Text('Create account'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _login() async {
+    try {
+      await FirebaseAuth.instance.signInWithEmailAndPassword(
+        email: _emailController.text,
+        password: _passwordController.text,
+      );
+      if (mounted) {
+        if (_controller.index == 1) {
+          Navigator.of(context).pushReplacement(
+            MaterialPageRoute(builder: (_) => const PatientDashboard()),
+          );
+        } else {
+          Navigator.of(context).pushReplacement(
+            MaterialPageRoute(builder: (_) => const DoctorDashboard()),
+          );
+        }
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Login failed: \$e')),
+      );
+    }
+  }
+}
+

--- a/lib/screens/patient_dashboard.dart
+++ b/lib/screens/patient_dashboard.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+class PatientDashboard extends StatefulWidget {
+  const PatientDashboard({super.key});
+
+  @override
+  State<PatientDashboard> createState() => _PatientDashboardState();
+}
+
+class _PatientDashboardState extends State<PatientDashboard> {
+  DateTime _selectedDate = DateTime.now();
+  String? _service;
+  String? _doctorId;
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Patient Dashboard')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Welcome, ${user?.email ?? ''}',
+                style: Theme.of(context).textTheme.headline6,
+              ),
+              const SizedBox(height: 16),
+              Text('Available Doctors',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              StreamBuilder<QuerySnapshot>(
+                stream: FirebaseFirestore.instance
+                    .collection('doctors')
+                    .snapshots(),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  final docs = snapshot.data!.docs;
+                  return Column(
+                    children: docs.map((d) {
+                      final data = d.data() as Map<String, dynamic>;
+                      return RadioListTile<String>(
+                        value: d.id,
+                        groupValue: _doctorId,
+                        onChanged: (value) {
+                          setState(() {
+                            _doctorId = value;
+                          });
+                        },
+                        title: Text(data['name'] ?? ''),
+                        subtitle: Text(data['specialization'] ?? ''),
+                      );
+                    }).toList(),
+                  );
+                },
+              ),
+
+              const SizedBox(height: 16),
+              TableCalendar(
+                focusedDay: _selectedDate,
+                firstDay: DateTime.now(),
+                lastDay: DateTime.now().add(const Duration(days: 365)),
+                selectedDayPredicate: (day) => isSameDay(day, _selectedDate),
+                onDaySelected: (selectedDay, focusedDay) {
+                  setState(() {
+                    _selectedDate = selectedDay;
+                  });
+                },
+              ),
+              const SizedBox(height: 16),
+              DropdownButton<String>(
+                value: _service,
+                hint: const Text('Select service'),
+                items: const [
+                  DropdownMenuItem(value: 'consultation', child: Text('Consultation')),
+                  DropdownMenuItem(value: 'checkup', child: Text('Checkup')),
+                ],
+                onChanged: (value) {
+                  setState(() {
+                    _service = value;
+                  });
+                },
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: (_doctorId != null && _service != null)
+                    ? () async {
+                        await FirebaseFirestore.instance
+                            .collection('appointments')
+                            .add({
+                          'date': _selectedDate,
+                          'service': _service,
+                          'patientId': user?.uid,
+                          'doctorId': _doctorId,
+                        });
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Appointment booked')),
+                        );
+                      }
+                    : null,
+                child: const Text('Book Appointment'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class SignUpScreen extends StatefulWidget {
+  final bool isDoctor;
+  const SignUpScreen({super.key, required this.isDoctor});
+
+  @override
+  State<SignUpScreen> createState() => _SignUpScreenState();
+}
+
+class _SignUpScreenState extends State<SignUpScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _specializationController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign Up')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            const SizedBox(height: 12),
+            if (widget.isDoctor)
+              TextField(
+                controller: _specializationController,
+                decoration: const InputDecoration(labelText: 'Specialization'),
+              ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: 'Password'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _register,
+              child: const Text('Create Account'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _register() async {
+    try {
+      final cred = await FirebaseAuth.instance.createUserWithEmailAndPassword(
+        email: _emailController.text,
+        password: _passwordController.text,
+      );
+      final uid = cred.user!.uid;
+      final profile = {
+        'name': _nameController.text,
+      };
+      if (widget.isDoctor) {
+        profile['specialization'] = _specializationController.text;
+      }
+      await FirebaseFirestore.instance
+          .collection(widget.isDoctor ? 'doctors' : 'patients')
+          .doc(uid)
+          .set(profile);
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Sign up failed: $e')),
+      );
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,10 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  firebase_core: ^2.17.0
+  firebase_auth: ^4.1.2
+  cloud_firestore: ^4.9.1
+  table_calendar: ^3.0.9
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,12 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:untitled10/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('renders login screen', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.text('Login'), findsOneWidget);
+    expect(find.text('Create account'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add `HomeScreen` routing authenticated users to dashboards
- update `main.dart` to use `HomeScreen`
- wait for asynchronous widgets in widget test

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848927d0b6c8321bcf7251cf17d2699